### PR TITLE
IndexError when running main.py without data.mat

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,6 +74,9 @@ if __name__ == '__main__':
     data_file_name = 'data.mat'
     if os.path.isfile(data_file_name):
         data = sio.loadmat(data_file_name)
+        for name, value in data.items():
+            if name[0]=='b' and value.ndim==2 and value.shape[0]==1:
+                data[name] = value.reshape(-1)
     else:
         data = train_neural_network(model_size=[784, 300, 10], file_name=data_file_name)
 
@@ -104,7 +107,7 @@ if __name__ == '__main__':
         elapsed_time = time.time() - start
         print('tensorflow-based execution time:', elapsed_time)
         refined_W[:, i] = w_tf[:-1]
-        refined_b[0, i] = w_tf[-1]
+        refined_b[i] = w_tf[-1]
 
         total_time += elapsed_time
 


### PR DESCRIPTION
This PR fixes `IndexError` on running main.py without data.mat.

When I ran main.py without data.mat, it crashed as follows:
```
Traceback (most recent call last):
  File "main.py", line 108, in <module>
    refined_b[0, i] = w_tf[-1]
IndexError: too many indices for array
```

This PR fixes the problem by converting biases to 1-D array after `scipy.io.loadmat()`.