### PR TITLE
ValueError when initial weights to GeneralSoftmaxModel are given

### DIFF
--- a/GeneralSoftmaxModel.py
+++ b/GeneralSoftmaxModel.py
@@ -58,7 +58,7 @@ class GeneralSoftmaxModel:
         with self._graph.as_default():
             self._x = tf.placeholder(self._computation_precision, [None, input_len])
             self._target = tf.placeholder(self._computation_precision, [None, output_len])
-            self._keep_prob = tf.placeholder(tf.float32, 1)
+            self._keep_prob = tf.placeholder(tf.float32)
 
             # create layers
             self._nn_signals = [self._x]
@@ -71,7 +71,7 @@ class GeneralSoftmaxModel:
             for h in range(num_layers):
                 init_w = initial_weights[h][0]
                 init_b = initial_weights[h][1]
-                if (init_w.shape[0] != out_dim) or (init_w.shape[1] != init_b.shape):
+                if (init_w.shape[0] != out_dim) or (init_w.shape[1] != init_b.size):
                     raise ValueError('Inconsistent dimensions for initial weights.')
 
                 W = tf.Variable(init_w)


### PR DESCRIPTION
This PR fixes `ValueError` (Inconsistent dimensions for initial weights) on giving initial weights to `GeneralSoftmaxModel`.


When I gave trimmed weights to `GeneralSoftmaxModel` to evaluate accuracies after trimming, I got the following error:
```
Traceback (most recent call last):
  File "main.py", line 126, in <module>
    train_neural_network(model_size=None, file_name=data_file_name, initial_weights=initial_weights, epochs=0)
  File "main.py", line 25, in train_neural_network
    model = nn_model.GeneralSoftmaxModel(initial_weights=initial_weights, regulize=True, regularization_gain=5e-4)
  File "C:\blahblahblah\Net-Trim-v1\GeneralSoftmaxModel.py", line 32, in __init__
    self._create_initialized_graph(initial_weights)
  File "C:\blahblahblah\GeneralSoftmaxModel.py", line 75, in _create_initialized_graph
    raise ValueError('Inconsistent dimensions for initial weights.')
ValueError: Inconsistent dimensions for initial weights.
```

`GeneralSoftmaxModel._create_initialized_graph()` has two problems:
* tries to compare scalar with tuple (on line #74)
* probability for `tf.nn.dropout()` is defined as an array, not a scalar (on line #61)

This PR fixes the problem and adds an evaluation after trimming as a test case for the fix.